### PR TITLE
Drop pipe-tools dependency and use bash part.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,19 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-## 3.0.0
+## v3.1.0 - 2022-01-26
+
+### Added
+
+* [PIPELINE-741](https://globalfishingwatch.atlassian.net/browse/PIPELINE-741): Adds
+  New docker base image [gfw-bash-pipeline](https://github.com/GlobalFishingWatch/pipe-bash-scripts)
+
+### Removed
+
+* [PIPELINE-741](https://globalfishingwatch.atlassian.net/browse/PIPELINE-741): Removes
+  Dependencies with `pipe-tools`.
+
+## v3.0.0 - 2022-01-17
 
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-pipeline:latest
+FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-bash-pipeline:latest
 
 
 # Setup local application dependencies

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,8 @@ include LICENSE
 include CHANGES.md
 include MANIFEST.in
 include README.md
-include setup.py
 include requirements.txt
-recursive-include  assets *
-recursive-include  pipe_vms_norway *
+include setup.py
+recursive-include assets *
+recursive-include scripts *
+recursive-include pipe_vms_norway *

--- a/pipe_vms_norway/__init__.py
+++ b/pipe_vms_norway/__init__.py
@@ -2,7 +2,7 @@
 Pipeline for processing the Norway VMS data
 """
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 __author__ = 'Matias Piano'
 __email__ = 'engineers@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-vms-norway'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.2.1#egg=pipe-tools
+jinja2-cli==0.8.0
+pytest==6.2.5

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,7 +17,6 @@ fi
 case $1 in
 
   fetch_normalized_vms)
-
     xdaterange ${THIS_SCRIPT_DIR}/fetch_normalized_vms.sh "${@:2}"
     ;;
 

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,6 @@ PACKAGE_NAME='pipe-vms-norway'
 
 package = __import__('pipe_vms_norway')
 
-
-DEPENDENCIES = [
-    "jinja2-cli",
-    "pipe-tools==3.2.1"
-]
-
 with codecs.open('README.md', encoding='utf-8') as f:
     readme = f.read().strip()
 
@@ -25,7 +19,6 @@ setup(
     author_email=package.__email__,
     description=package.__doc__.strip(),
     include_package_data=True,
-    install_requires=DEPENDENCIES,
     license="Apache 2.0",
     long_description=readme,
     name=PACKAGE_NAME,


### PR DESCRIPTION
Removes the dependencies in `setup.py`, pinned dependencies in `requirements.txt`.
- Uses the new base image `gfw-bash-pipeline` in dockerfile.
- No more dependency with `pipe-tools`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-741