### PR TITLE
Fixed Norway core segment failed because of positions with null lat or lon. PIPELINE-1454

### DIFF
--- a/assets/fetch-normalized-vms.sql.j2
+++ b/assets/fetch-normalized-vms.sql.j2
@@ -42,3 +42,7 @@ FROM
   raw_vms_positions_normalized
 WHERE
   ssvid IS NOT NULL
+  AND (
+    lat IS NOT NULL 
+    OR lon IS NOT NULL
+    )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     license="Apache 2.0",
     long_description=readme,
     name=PACKAGE_NAME,
+    py_modules=[],
     url=package.__source__,
     version=package.__version__,
     zip_safe=True


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-1454